### PR TITLE
add_force_option_when_force

### DIFF
--- a/lib/puppet/provider/mdadm/mdadm.rb
+++ b/lib/puppet/provider/mdadm/mdadm.rb
@@ -14,6 +14,11 @@ Puppet::Type.type(:mdadm).provide(:mdadm) do
     cmd << "-e #{resource[:metadata]}"
     cmd << resource.name
     cmd << "--level=#{resource[:level]}"
+
+    if resource[:force]
+      cmd << "--force"
+    end    
+    
     cmd << "--raid-devices=#{resource[:active_devices] || resource[:devices].size}"
     cmd << "--spare-devices=#{resource[:spare_devices]}" if resource[:spare_devices]
     cmd << "--parity=#{resource[:parity]}" if resource[:parity]


### PR DESCRIPTION
Solve:
Execution of '/bin/yes | /sbin/mdadm --create -e 0.9 /dev/md/TSTNOAH_arch --level=0 --raid-devices=1 /dev/mapper/TSTNOAH_arch' returned 2: mdadm: '1' is an unusual number of drives for an array, so it is probably  a mistake.  If you really mean it you will need to specify --force before setting the number of drives.